### PR TITLE
alternate way to do plagiarism check except for 100% copy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["flit_core >=3.4,<4"]
+requires = ["flit_core >=3.4,<4", "scikit-learn"]
 build-backend = "flit_core.buildapi"
 
 # These dependencies are only installed when developer mode is enabled


### PR DESCRIPTION
@NagariaHussain After following your Youtube video, I thought I can raise a PR with alternate ways to find plagiarism as hash computation would help you to find if its 100% match only. Here I have added a plagiarism check with tf-idf-vectors computation and finding the similarity between vector using cosine similarity.  Let me know if this is ok and share your suggestions to improve. Thanks